### PR TITLE
Add timeouts to readRTC() and readRTCregister() functions to prevent RTC...

### DIFF
--- a/waspmote-api/WaspRTC.cpp
+++ b/waspmote-api/WaspRTC.cpp
@@ -319,6 +319,7 @@ void WaspRTC::readRTC(uint8_t endAddress)
 		else
 		{
 			timeout++;
+			delay(100);
 		}
 	}
 	


### PR DESCRIPTION
... code from hanging if no data is received on the I2C bus.

Signed-off-by: Nick D'Ademo nickdademo@gmail.com
