### PR TITLE
Fix for conflict with CAN library

### DIFF
--- a/libraries/_3G/Wasp3G.h
+++ b/libraries/_3G/Wasp3G.h
@@ -211,7 +211,7 @@
 #define NAK		0x15
 #define SOH		0x01
 #define EOT		0x04
-#define CAN		0x18
+#define CANC	0x18
 
 
 


### PR DESCRIPTION
CAN is the class name of the CAN library. Defining CAN as a variable turns into problems if you want to combine these 2 libraries
