### PR TITLE
Fixed incorrect waking up procedure

### DIFF
--- a/libraries/LoRaWAN/WaspLoRaWAN.cpp
+++ b/libraries/LoRaWAN/WaspLoRaWAN.cpp
@@ -5893,17 +5893,20 @@ uint8_t WaspLoRaWAN::wakeUp()
 
 	memset(ans1,0x00,sizeof(ans1));
 	
+	setBaudrate(9600);
 	beginUART();
   	
 	// create "ok" answer
 	sprintf_P(ans1,(char*)pgm_read_word(&(table_LoRaWAN_ANSWERS[0])));
 	
 	printByte(0x00,_uart);
+	closeUART();
+	setBaudrate(57600);
+	beginUART();
 	printByte(0x55,_uart);
 
 	delay(500);
 	
-	sleep(100);
 	status = waitFor(ans1,500);
 	
 	if (status == 1)


### PR DESCRIPTION
The procedure for waking up the LoRa chip from sleep was incorrect and not working. This was because section 1.4 of the [LoRa radio datasheet ](http://ww1.microchip.com/downloads/en/DeviceDoc/40001784F.pdf) seemed to be misinterpreted. Just sending 0x00 on UART does not qualify as a break condition. This 0x00 has to be at a baud rate lower than the default 57600 bps. This hotfix fixes that and removes the unnecessary additional sleep entry,