### PR TITLE
Feat/optod compensation

### DIFF
--- a/libraries/SensorXtr/WaspSensorXtr.cpp
+++ b/libraries/SensorXtr/WaspSensorXtr.cpp
@@ -4912,7 +4912,7 @@ uint8_t Aqualabo_OPTOD::enableCompensation(uint8_t temperature, uint8_t atm_pres
 */
 uint8_t Aqualabo_OPTOD::enableTemperatureCompensation(uint8_t enable)
 {
-	return enableCompensation(1, atmPressureCompensation, salinityCompensation);
+	return enableCompensation(enable, atmPressureCompensation, salinityCompensation);
 }
 
 /* enableAtmPressureCompensation enables measurement atmospheric pressure compensation
@@ -4924,7 +4924,7 @@ uint8_t Aqualabo_OPTOD::enableTemperatureCompensation(uint8_t enable)
 */
 uint8_t Aqualabo_OPTOD::enableAtmPressureCompensation(uint8_t enable)
 {
-	return enableCompensation(temperatureCompensation, 1, salinityCompensation);
+	return enableCompensation(temperatureCompensation, enable, salinityCompensation);
 }
 
 /* enableSalinityCompensation enables measurement salinity compensation
@@ -4936,7 +4936,7 @@ uint8_t Aqualabo_OPTOD::enableAtmPressureCompensation(uint8_t enable)
 */
 uint8_t Aqualabo_OPTOD::enableSalinityCompensation(uint8_t enable)
 {
-	return enableCompensation(temperatureCompensation, atmPressureCompensation, 1);
+	return enableCompensation(temperatureCompensation, atmPressureCompensation, enable);
 }
 /* setAtmPressureCompValue - sets an atmospheric pressure value to be used in measurement
 	compensation instead of the default.

--- a/libraries/SensorXtr/WaspSensorXtr.h
+++ b/libraries/SensorXtr/WaspSensorXtr.h
@@ -1133,10 +1133,20 @@ class Aqualabo_OPTOD: public AqualaboWaterXtr
 		uint8_t read();
 		uint8_t readSerialNumber();
 		void calibrationProcess(uint8_t parameter);
+		uint8_t enableTemperatureCompensation(uint8_t enable);
+		uint8_t enableAtmPressureCompensation(uint8_t enable);
+		uint8_t enableSalinityCompensation(uint8_t enable);
+		uint8_t setAtmPressureCompValue(float value);
+		uint8_t setSalinityCompValue(float value);
 		
 	private:
 		WaspSDI12 sdi12Sensor = WaspSDI12(ANA2);
 		uint8_t socket;
+		uint8_t temperatureCompensation = 0x80;
+		uint8_t atmPressureCompensation = 0x80;
+		uint8_t salinityCompensation = 0x80;
+
+		uint8_t enableCompensation(uint8_t temperature, uint8_t atm_pressure, uint8_t salinity);
 };
 
 

--- a/libraries/SensorXtr/utility/AqualaboModbusSensors.cpp
+++ b/libraries/SensorXtr/utility/AqualaboModbusSensors.cpp
@@ -618,7 +618,7 @@ uint8_t aqualaboModbusSensorsClass::enableCompensation(uint8_t temperature, uint
 
 	uint16_t config_reg;
 	uint16_t new_config_reg;
-	uint16_t config_reg_bit_mask;
+	uint16_t config_reg_bit_mask = 0x0000;
 
 	if (temperature)
 	{
@@ -669,7 +669,7 @@ uint8_t aqualaboModbusSensorsClass::enableCompensation(uint8_t temperature, uint
 
 		if( new_config_reg != config_reg )
 		{
-			USB.printf("Writing new config %04x\n", config_reg);
+			USB.printf("Writing new config %04x\n", new_config_reg);
 			status = sensor.writeSingleRegister(MEAS_TYPE_CONFIG_REG, new_config_reg);
 			delay(100);
 		}

--- a/libraries/SensorXtr/utility/AqualaboModbusSensors.h
+++ b/libraries/SensorXtr/utility/AqualaboModbusSensors.h
@@ -72,6 +72,13 @@
 #define NEW_MEAS_REG		0x01
 #define TEMP_COEF_LIST_REG	0x014C
 #define RESTORE_CALIB_REG	0x0002
+#define COMP_VAL_1_REG			0x005F
+#define COMP_VAL_2_REG			0x0061
+#define MEAS_TYPE_CONFIG_REG	0x00A6
+
+#define MEAS_TYPE_COMP_TEMP_BIT		0x0010
+#define MEAS_TYPE_COMP_VAL_1_BIT	0x0020
+#define MEAS_TYPE_COMP_VAL_2_BIT	0x0040
 
 
 //NTU sensor standard calibration registers
@@ -187,6 +194,9 @@ class aqualaboModbusSensorsClass
 		uint16_t readAverage();
 		uint8_t writeParamConfig(uint8_t paramNumber, uint8_t range);
 		uint16_t readParamConfig(uint8_t paramNumber);
+		uint8_t readEnableCompensationFlags(void);
+		uint8_t enableCompensation(uint8_t temperature, uint8_t comp_val_1, uint8_t comp_val_2);
+		uint8_t setCompValue(uint8_t comp_value_n, float value);
 		
 		// Sensor calibration functions
 		uint8_t calibrate(uint8_t sensor, uint8_t parameter, uint8_t step, float value);


### PR DESCRIPTION
This branch fixes a problem where optod probes are not compensating their for temperature (or any other externally provided parameters for that matter). This is done by providing a way to set correct flags in the measurement configuration register.